### PR TITLE
fix(TemplateStudio): apply prop type validation for redux mapping - I3

### DIFF
--- a/src/TemplateStudio/index.js
+++ b/src/TemplateStudio/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import TemplateLibrary from 'cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
@@ -25,8 +26,6 @@ const TLWrapper = styled.div`
   }
 `;
 
-/* eslint react/prop-types: 0 */
-/* This disables ESLint because Redux is handling props */
 class TemplateStudio extends PureComponent {
   constructor(props) {
     super(props);
@@ -37,6 +36,11 @@ class TemplateStudio extends PureComponent {
       addToCont: mockAddToCont,
     };
   }
+
+  static propTypes = {
+    templates: PropTypes.array,
+    outputTemplates: PropTypes.func,
+  };
 
   render() {
     return (


### PR DESCRIPTION
Issue #3 

Finishes PR #10 by addressing the changes described [here](https://github.com/accordproject/template-studio-v2/pull/10#discussion_r277357104).