### PR TITLE
 feat(TemplateStudio): migrate fetch funcs and init add template func - I4

### DIFF
--- a/src/TemplateStudio/index.js
+++ b/src/TemplateStudio/index.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import TemplateLibrary from 'cicero-ui';
+import TemplateLibrary from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
 
-import { getTemplates } from '../actions';
+import { getTemplates, addNewTemplateAction } from '../actions';
 import Header from './Header';
 
 const mockUpload = () => { console.log('upload'); };
@@ -38,9 +38,14 @@ class TemplateStudio extends PureComponent {
     };
   }
 
+  componentDidMount() {
+    this.props.fetchAPTemplates();
+  }
+
   static propTypes = {
     templates: PropTypes.array,
-    outputTemplates: PropTypes.func,
+    fetchAPTemplates: PropTypes.func,
+    addNewTemplate: PropTypes.func,
   };
 
   render() {
@@ -52,9 +57,8 @@ class TemplateStudio extends PureComponent {
             templates={this.props.templates}
             upload={this.state.upload}
             import={this.state.import}
-            addTemp={this.state.addTemp}
+            addTemp={this.props.addNewTemplate}
             addToCont={this.state.addToCont}
-            outputTemplates={this.props.outputTemplates}
           />
         </TLWrapper>
       </div>
@@ -67,7 +71,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  outputTemplates: templates => dispatch(getTemplates(templates)),
+  fetchAPTemplates: () => dispatch(getTemplates()),
+  addNewTemplate: () => dispatch(addNewTemplateAction()),
 });
 
 export default connect(

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,4 +1,7 @@
-export const getTemplates = templates => ({
+export const getTemplates = () => ({
   type: 'GET_AP_TEMPLATES',
-  templates,
+});
+
+export const addNewTemplateAction = () => ({
+  type: 'ADD_NEW_TEMPLATE',
 });

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,11 +1,36 @@
+
+import { TemplateLibrary } from '@accordproject/cicero-core';
+import { version as ciceroVersion } from '@accordproject/cicero-core/package.json';
+
 import { all, takeLatest, put } from 'redux-saga/effects';
 
-export function* pushTemplatesToStore(action) {
-  yield put({ type: 'AP_TEMPLATES_RECEIVED', templates: action.templates });
+export function* pushTemplatesToStore() {
+  try {
+    const templateLibrary = new TemplateLibrary();
+    const templateIndex = yield templateLibrary
+      .getTemplateIndex({ latestVersion: false, ciceroVersion });
+    const templateIndexArray = Object.values(templateIndex);
+    yield put({ type: 'AP_TEMPLATES_RECEIVED', templates: templateIndexArray });
+  } catch (err) {
+    yield put({ type: 'AP_TEMPLATES_ERROR', error: err });
+  }
+}
+
+export function* addNewTemplateToStore() {
+  yield put({
+    type: 'ADD_NEW_TEMPLATE_SUCCEEDED',
+    template: {
+      uri: 'Uri',
+      name: 'Temporary New Template',
+      version: '1.0.0',
+      description: 'This is mock data to showcase an action to add a new template.',
+    },
+  });
 }
 
 function* actionWatcher() {
   yield takeLatest('GET_AP_TEMPLATES', pushTemplatesToStore);
+  yield takeLatest('ADD_NEW_TEMPLATE', addNewTemplateToStore);
 }
 
 export default function* rootSaga() {

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,13 +1,20 @@
 const initialState = {
   templatesAP: [],
+  error: null,
 };
 
 const AP_TEMPLATES_RECEIVED = 'AP_TEMPLATES_RECEIVED';
+const AP_TEMPLATES_ERROR = 'AP_TEMPLATES_ERROR';
+const ADD_NEW_TEMPLATE_SUCCEEDED = 'ADD_NEW_TEMPLATE_SUCCEEDED';
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case AP_TEMPLATES_RECEIVED:
       return { ...state, templatesAP: action.templates };
+    case ADD_NEW_TEMPLATE_SUCCEEDED:
+      return { ...state, templatesAP: [...state.templatesAP, action.template] };
+    case AP_TEMPLATES_ERROR:
+      return { ...state, error: action.error };
     default:
       return state;
   }


### PR DESCRIPTION
Issue #4 

- Migrate fetch functionality from Template Library
- Create sagas for adding templates to the Template Library

**FLAGS**:
- TSv2 will now handle fetching and propagating templates down to Template Library.
- Coincides with the PR in Cicero-UI [here](https://github.com/accordproject/cicero-ui/pull/16).