### PR TITLE
 feat(src): implement logger and adjust import - I4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,9 +126,9 @@
       }
     },
     "@accordproject/cicero-ui": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.1.tgz",
-      "integrity": "sha512-UgeacGHt7rfvg2bc0XRrmzDJ9m8SrH1mOlTR9EKn49P1jeJum2N+cWwf5rE6APHdeiGY9Zx3A+zXa6QShE0flg==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.2.tgz",
+      "integrity": "sha512-MaZO0LfqXz3m4kqtfBp1bdf6oz4lYsPI80V+0rNjl0gezwByQcFFhDlRyMCmAywA5UgkwCmCJn48sVSBf9IIwA==",
       "requires": {
         "lodash": "^4.17.11",
         "node-sass": "^4.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,6 +3389,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -9551,6 +9556,14 @@
       "requires": {
         "lodash": "^4.2.0",
         "symbol-observable": "^1.0.2"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
       }
     },
     "redux-saga": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-dom": "^16.8.6",
     "react-redux": "^7.0.1",
     "redux": "^4.0.1",
+    "redux-logger": "^3.0.6",
     "redux-saga": "^1.0.2",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.86.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.12.0",
-    "@accordproject/cicero-ui": "0.0.1",
+    "@accordproject/cicero-ui": "0.0.2",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/TemplateStudio/index.js
+++ b/src/TemplateStudio/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import TemplateLibrary from '@accordproject/cicero-ui';
+import { TemplateLibrary } from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
 

--- a/src/TemplateStudio/index.js
+++ b/src/TemplateStudio/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { TemplateLibrary } from '@accordproject/cicero-ui';
+import TemplateLibrary from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
 
@@ -75,7 +75,4 @@ const mapDispatchToProps = dispatch => ({
   addNewTemplate: () => dispatch(addNewTemplateAction()),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(TemplateStudio);
+export default connect(mapStateToProps, mapDispatchToProps)(TemplateStudio);

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,15 @@ import reducer from './store/reducer';
 import rootSaga from './sagas';
 
 const sagaMiddleware = createSagaMiddleware();
+const middlewares = [sagaMiddleware];
+
+if (process.env.NODE_ENV === 'development') {
+  middlewares.push(logger);
+}
 
 const store = createStore(
   reducer,
-  applyMiddleware(sagaMiddleware, logger),
+  applyMiddleware(...middlewares),
 );
 sagaMiddleware.run(rootSaga);
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import createSagaMiddleware from 'redux-saga';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
+import logger from 'redux-logger';
 
 import App from './TemplateStudio';
 import reducer from './store/reducer';
@@ -12,7 +13,7 @@ const sagaMiddleware = createSagaMiddleware();
 
 const store = createStore(
   reducer,
-  applyMiddleware(sagaMiddleware),
+  applyMiddleware(sagaMiddleware, logger),
 );
 sagaMiddleware.run(rootSaga);
 

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -20,7 +20,7 @@ export function* addNewTemplateToStore() {
   yield put({
     type: 'ADD_NEW_TEMPLATE_SUCCEEDED',
     template: {
-      uri: 'Uri',
+      uri: `${Date.now()}`,
       name: 'Temporary New Template',
       version: '1.0.0',
       description: 'This is mock data to showcase an action to add a new template.',


### PR DESCRIPTION
Issue #4 

- Temporarily adjust mock template URI for a unique key to add to array
- Adjust import of node module after Cicero-UI has been published to `npm`
- Install and implement `redux-logger` in development only

**FLAGS**:
- Pivoted from a Redux store state display in a window for the already established console logger