### PR TITLE
fix(src): import contract editor code and modularize - I4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,16 +126,154 @@
       }
     },
     "@accordproject/cicero-ui": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.4.tgz",
-      "integrity": "sha512-yW3SyUYy0u/Mr8IiyMzzZsA33PIxB51iMxX33lLZWzdkZPV66rj92hriGIHK3twOXiMt93cHA5d0mjLtxMLkJg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.5.tgz",
+      "integrity": "sha512-8Mb1H55UxJT8NN7HFE2YVhB2SSNNAA3O7QhdPz4MLz3xIcp1qF85EqtttfJgUY9Rnp8HNDc0YkCRulTXkGkBZA==",
       "requires": {
+        "@accordproject/cicero-core": "^0.12.2",
+        "@accordproject/markdown-editor": "^0.2.7",
         "lodash": "^4.17.11",
         "node-sass": "^4.11.0",
         "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
         "styled-components": "^4.2.0"
+      },
+      "dependencies": {
+        "@accordproject/cicero-core": {
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.12.2.tgz",
+          "integrity": "sha512-0n4uiQEV5RsUlCGLyoJdPF4RQhRRHNt0sVrpn07U776b1jljy1unki7GRYbCRxtS6LG06+p5YgC0nILAPBEY1g==",
+          "requires": {
+            "@accordproject/ergo-compiler": "0.8.2",
+            "axios": "0.18.0",
+            "composer-concerto": "0.70.2",
+            "debug": "4.1.0",
+            "fast-safe-stringify": "2.0.5",
+            "ietf-language-tag-regex": "0.0.5",
+            "json-stable-stringify": "1.0.1",
+            "jszip": "3.1.5",
+            "moment-mini": "2.22.1",
+            "moo": "0.4.3",
+            "nearley": "2.15.1",
+            "node-cache": "4.2.0",
+            "nunjucks": "3.2.0",
+            "request": "2.87.0",
+            "request-promise-native": "1.0.5",
+            "semver": "5.6.0",
+            "uuid": "3.3.2",
+            "winston": "^3.2.1",
+            "xregexp": "4.1.1"
+          }
+        },
+        "@accordproject/ergo-compiler": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.8.2.tgz",
+          "integrity": "sha512-6kwNuLQF9y1Wf/uZn9YatZkBd4vbgKRopFX6ts0HYtsXtCE27UyRZgIGiIgz6vu3QgYrfm4nNZr2ej+5+MBA+w==",
+          "requires": {
+            "composer-concerto": "0.70.2",
+            "debug": "4.1.0",
+            "fast-safe-stringify": "2.0.5",
+            "jsome": "2.5.0",
+            "moment-mini": "2.22.1",
+            "winston": "^3.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "@accordproject/ergo-compiler": {
@@ -149,6 +287,44 @@
         "jsome": "2.5.0",
         "moment-mini": "2.22.1",
         "winston": "^3.2.1"
+      }
+    },
+    "@accordproject/markdown-editor": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.2.7.tgz",
+      "integrity": "sha512-vBKVTHMyUyQ+hzMIkJidPHfSbbWjoQ6qf1XFboOs+QjuG/fY33a7ZjdJylIAWaF1mGy4hnnbj7YyTtyvpL8XRg==",
+      "requires": {
+        "commonmark": "^0.28.1",
+        "css-loader": "^2.1.0",
+        "immutable": "^3.8.1",
+        "prop-types": "^15.6.2",
+        "react": "^16.7.0",
+        "react-dom": "^16.7.0",
+        "react-immutable-proptypes": "^2.1.0",
+        "semantic-ui-css": "^2.4.1",
+        "semantic-ui-react": "^0.84.0",
+        "slate": "^0.44.9",
+        "slate-html-serializer": "^0.7.34",
+        "slate-plain-serializer": "^0.6.33",
+        "slate-react": "^0.21.15",
+        "style-loader": "^0.23.1",
+        "styled-components": "^4.1.3"
+      },
+      "dependencies": {
+        "semantic-ui-react": {
+          "version": "0.84.0",
+          "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.84.0.tgz",
+          "integrity": "sha512-OOqdtH+hBxVlh/lQa+zet9MEPcA8cBUo7ePVYZhx82hwF5Ky47FiWrgLk3ZSNie7bb4VkuiuLR9y5cY0EooRlw==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "@semantic-ui-react/event-stack": "^3.0.1",
+            "classnames": "^2.2.6",
+            "keyboard-key": "^1.0.2",
+            "lodash": "^4.17.11",
+            "prop-types": "^15.6.2",
+            "shallowequal": "^1.1.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -1699,14 +1875,12 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-      "dev": true
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -2239,8 +2413,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2576,8 +2749,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -2892,6 +3064,17 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "commonmark": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.28.1.tgz",
+      "integrity": "sha1-Buq41SM4uDn6Gi11rwCF7tGxvq4=",
+      "requires": {
+        "entities": "~ 1.1.1",
+        "mdurl": "~ 1.0.1",
+        "minimist": "~ 1.2.0",
+        "string.prototype.repeat": "^0.2.0"
+      }
     },
     "compare-versions": {
       "version": "3.4.0",
@@ -3249,7 +3432,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
       "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
-      "dev": true,
       "requires": {
         "camelcase": "^5.2.0",
         "icss-utils": "^4.1.0",
@@ -3295,8 +3477,7 @@
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssom": {
       "version": "0.3.6",
@@ -3562,6 +3743,11 @@
         "randombytes": "^2.0.0"
       }
     },
+    "direction": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
+      "integrity": "sha1-zl15f5fib4vnvv9T99xA4cGp7Ew="
+    },
     "discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -3717,8 +3903,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "enabled": {
       "version": "1.0.2",
@@ -3756,8 +3941,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "env-variable": {
       "version": "0.0.5",
@@ -4248,6 +4432,11 @@
       "requires": {
         "estraverse": "^4.1.0"
       }
+    },
+    "esrever": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/esrever/-/esrever-0.2.0.tgz",
+      "integrity": "sha1-lunSj08bGnZ4TNXUkOquAQ50B7g="
     },
     "estraverse": {
       "version": "4.2.0",
@@ -5403,6 +5592,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-document": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
+      "integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -5420,6 +5614,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "get-window": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
+      "integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
+      "requires": {
+        "get-document": "1"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -5913,14 +6115,12 @@
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-      "dev": true
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
     },
     "icss-utils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.0.tgz",
       "integrity": "sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==",
-      "dev": true,
       "requires": {
         "postcss": "^7.0.14"
       }
@@ -5962,6 +6162,11 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -6013,8 +6218,7 @@
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-      "dev": true
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "indexof": {
       "version": "0.0.1",
@@ -6269,6 +6473,16 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-hotkey": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.4.tgz",
+      "integrity": "sha512-Py+aW4r5mBBY18TGzGz286/gKS+fCQ0Hee3qkaiSmEPiD0PqFpe0wuA3l7rTOUKyeXl8Mxf3XzJxIoTlSv+kxA=="
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6376,6 +6590,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-window": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6401,6 +6620,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-base64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
+      "integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
     },
     "isstream": {
       "version": "0.1.2",
@@ -7249,7 +7473,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -7435,7 +7658,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
@@ -7617,6 +7839,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -8989,7 +9216,6 @@
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
       "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -8999,14 +9225,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -9017,7 +9241,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
-      "dev": true,
       "requires": {
         "postcss": "^7.0.5"
       }
@@ -9026,7 +9249,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
       "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
-      "dev": true,
       "requires": {
         "postcss": "^7.0.6",
         "postcss-selector-parser": "^6.0.0",
@@ -9037,7 +9259,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
       "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
-      "dev": true,
       "requires": {
         "postcss": "^7.0.6",
         "postcss-selector-parser": "^6.0.0"
@@ -9047,7 +9268,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
       "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
-      "dev": true,
       "requires": {
         "icss-replace-symbols": "^1.1.0",
         "postcss": "^7.0.6"
@@ -9057,7 +9277,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
       "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
-      "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -9352,6 +9571,11 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
       }
+    },
+    "react-immutable-proptypes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
+      "integrity": "sha1-Aj1vObsVyXwHHp5g0A0TbqxfoLQ="
     },
     "react-is": {
       "version": "16.8.6",
@@ -10148,7 +10372,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
@@ -10179,6 +10402,11 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
+    },
+    "selection-is-backward": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/selection-is-backward/-/selection-is-backward-1.0.0.tgz",
+      "integrity": "sha1-l6VGMxiKURq6ZBn8XB+pG0Z+a+E="
     },
     "selfsigned": {
       "version": "1.10.4",
@@ -10393,6 +10621,132 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
+    },
+    "slate": {
+      "version": "0.44.13",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.44.13.tgz",
+      "integrity": "sha512-GcDon/8iN6Mmonl7FucSDGs9KYDB7S9gs+fnnJDny5HFsHGGDTDwfBnRXMyKDC307sRZ+yhauqKSulHkoBdB9A==",
+      "requires": {
+        "debug": "^3.1.0",
+        "direction": "^0.1.5",
+        "esrever": "^0.2.0",
+        "is-plain-object": "^2.0.4",
+        "lodash": "^4.17.4",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3",
+        "type-of": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "slate-base64-serializer": {
+      "version": "0.2.102",
+      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.102.tgz",
+      "integrity": "sha512-44BI/jEbSMDNjEpOd92dVtpKyoFEaQtS3YgDoD30gHsvJvuzdRd/EQjp01BAUhDLLgDINi9qIHZS3AkpqKOtow==",
+      "requires": {
+        "isomorphic-base64": "^1.0.2"
+      }
+    },
+    "slate-dev-environment": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.2.2.tgz",
+      "integrity": "sha512-JZ09llrRQu6JUsLJCUlGC0lB1r1qIAabAkSd454iyYBq6lDuY//Bypi3Jo8yzIfzZ4+mRLdQvl9e8MbeM9l48Q==",
+      "requires": {
+        "is-in-browser": "^1.1.3"
+      }
+    },
+    "slate-hotkeys": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.2.9.tgz",
+      "integrity": "sha512-y+C/s5vJEmBxo8fIqHmUcdViGwALL/A6Qow3sNG1OHYD5SI11tC2gfYtGbPh+2q0H7O4lufffCmFsP5bMaDHqA==",
+      "requires": {
+        "is-hotkey": "0.1.4",
+        "slate-dev-environment": "^0.2.2"
+      }
+    },
+    "slate-html-serializer": {
+      "version": "0.7.39",
+      "resolved": "https://registry.npmjs.org/slate-html-serializer/-/slate-html-serializer-0.7.39.tgz",
+      "integrity": "sha512-ZNyVjqCasSa0M80+4W1bFXMhW4KJM7EE6dkyBOhQmIcuRX529xOahcz+6ZYK7fQn0Cyrye899OtX26LulAh/Ew==",
+      "requires": {
+        "type-of": "^2.0.1"
+      }
+    },
+    "slate-plain-serializer": {
+      "version": "0.6.39",
+      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.6.39.tgz",
+      "integrity": "sha512-EGl+Y+9Fw9IULtPg8sttydaeiAoaibJolMXNfqI79+5GWTQwJFIbg24keKvsTw+3f2RieaPu8fcrKyujKtZ7ZQ=="
+    },
+    "slate-prop-types": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.32.tgz",
+      "integrity": "sha512-eAh9QHEG4i0IjGCnncfmYdArHHbb2lDJxXIJWSypvtnPTNRxEYT5QQE+d/BxjES4xHve9DDJMPV2JenFQ7X42g=="
+    },
+    "slate-react": {
+      "version": "0.21.24",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.21.24.tgz",
+      "integrity": "sha512-fY1xUPCpsbTPGtiU0hc85JEzR5cf66Bqh5DLlDIfld/DljCKJoIVYR+EkFW5NuvvZPHhRjz4Ywz6IA/Krcjtug==",
+      "requires": {
+        "debug": "^3.1.0",
+        "get-window": "^1.1.1",
+        "is-window": "^1.0.2",
+        "lodash": "^4.1.1",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8",
+        "react-immutable-proptypes": "^2.1.0",
+        "selection-is-backward": "^1.0.0",
+        "slate-base64-serializer": "^0.2.102",
+        "slate-dev-environment": "^0.2.2",
+        "slate-hotkeys": "^0.2.9",
+        "slate-plain-serializer": "^0.7.1",
+        "slate-prop-types": "^0.5.32",
+        "slate-react-placeholder": "^0.1.20",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "memoize-one": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "slate-plain-serializer": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.7.1.tgz",
+          "integrity": "sha512-hyMGiRTFXMUD8/PocKgXLRd/hA4SCNn3SaLOziF5iEgTrj4l/xvqaA08wv493GsSUfZWB6n2BstRkg9Ln/uJ4A=="
+        }
+      }
+    },
+    "slate-react-placeholder": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/slate-react-placeholder/-/slate-react-placeholder-0.1.20.tgz",
+      "integrity": "sha512-A4xq1kS3V3YetFbLE/1dv+/SDVjx9zsZZepJqjcmkGK+evHU2yNkWjZXCg8MLMRtZJpGtYT/BE3+kHbkgT5Q4A=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -10844,6 +11198,11 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
+    },
     "string.prototype.trim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
@@ -10900,7 +11259,6 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
       "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
-      "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
         "schema-utils": "^1.0.0"
@@ -11178,6 +11536,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
+      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+    },
+    "tiny-warning": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
+      "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -11341,6 +11709,11 @@
         "mime-types": "~2.1.18"
       }
     },
+    "type-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
+      "integrity": "sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -11460,8 +11833,7 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4863,8 +4863,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4882,13 +4881,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4901,18 +4898,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5015,8 +5009,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5026,7 +5019,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5039,20 +5031,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5069,7 +5058,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5142,8 +5130,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5153,7 +5140,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5229,8 +5215,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5260,7 +5245,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5278,7 +5262,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5317,13 +5300,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.12.0",
-    "@accordproject/cicero-ui": "0.0.4",
+    "@accordproject/cicero-ui": "0.0.5",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/containers/App/__snapshots__/index.test.js.snap
+++ b/src/containers/App/__snapshots__/index.test.js.snap
@@ -4,43 +4,30 @@ exports[`<App /> on initialization renders page correctly 1`] = `
 <div>
   <Header />
   <Tile
+    handleSubmit={[Function]}
     header="Model"
     label="Model Mock: "
     textLabel="Current Model Value: "
   />
   <Tile
+    handleSubmit={[Function]}
     header="Logic"
     label="Logic Mock: "
     textLabel="Current Logic Value: "
   />
   <Tile
+    handleSubmit={[Function]}
     header="Sample"
     label="Sample Mock: "
     textLabel="Current Sample Value: "
   />
-  <styled.div>
-    <TemplateLibraryComponent
-      addTemp={[Function]}
-      addToCont={[Function]}
-      import={[Function]}
-      templates={Array []}
-      upload={[Function]}
-    />
-  </styled.div>
-</div>
-`;
-
-exports[`<TemplateStudio /> on initialization renders page correctly 1`] = `
-<div>
-  <Header />
-  <styled.div>
-    <Component
-      addTemp={[Function]}
-      addToCont={[Function]}
-      import={[Function]}
-      templates={Array []}
-      upload={[Function]}
-    />
-  </styled.div>
+  <EditorComponent />
+  <LibraryComponent
+    addNewTemplate={[Function]}
+    addToContract={[Function]}
+    importTemplate={[Function]}
+    templatesArray={Array []}
+    uploadCTA={[Function]}
+  />
 </div>
 `;

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Tile } from '@accordproject/cicero-ui';
+import { ContractEditor, Tile } from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
+import styled from 'styled-components';
 
 import { getTemplates, addNewTemplateAction } from '../../actions/templatesActions';
 import { updateModelMockAction } from '../../actions/modelActions';
@@ -15,6 +16,20 @@ const mockUpload = () => { console.log('upload'); };
 const mockImport = () => { console.log('import'); };
 const mockAddTemp = () => { console.log('addTemp'); };
 const mockAddToCont = (input) => { console.log('addToCont: ', input); };
+
+const EditorWrapper = styled.div`
+height: 700px;
+width: 485px;
+position: fixed;
+bottom: 0;
+right: 0;
+border: 2px solid #F9F9F9;
+overflow-y: auto;
+&::-webkit-scrollbar {
+  width: 4px;
+  background: transparent;
+}
+`;
 
 export class App extends PureComponent {
   constructor(props) {
@@ -68,6 +83,9 @@ export class App extends PureComponent {
           textValue={this.props.sampleMockValue}
           textLabel='Current Sample Value: '
         />
+        <EditorWrapper>
+          <ContractEditor />
+        </EditorWrapper>
         <LibraryComponent
           templatesArray={this.props.templates}
           uploadCTA={this.state.upload}

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { ContractEditor, Tile } from '@accordproject/cicero-ui';
+import { Tile } from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
-import styled from 'styled-components';
 
 import { getTemplates, addNewTemplateAction } from '../../actions/templatesActions';
 import { updateModelMockAction } from '../../actions/modelActions';
@@ -11,25 +10,12 @@ import { updateLogicMockAction } from '../../actions/logicActions';
 import { updateSampleMockAction } from '../../actions/sampleActions';
 import Header from '../Header';
 import LibraryComponent from '../TemplateLibrary';
+import EditorComponent from '../ContractEditor';
 
 const mockUpload = () => { console.log('upload'); };
 const mockImport = () => { console.log('import'); };
 const mockAddTemp = () => { console.log('addTemp'); };
 const mockAddToCont = (input) => { console.log('addToCont: ', input); };
-
-const EditorWrapper = styled.div`
-height: 700px;
-width: 485px;
-position: fixed;
-bottom: 0;
-right: 0;
-border: 2px solid #F9F9F9;
-overflow-y: auto;
-&::-webkit-scrollbar {
-  width: 4px;
-  background: transparent;
-}
-`;
 
 export class App extends PureComponent {
   constructor(props) {
@@ -83,9 +69,7 @@ export class App extends PureComponent {
           textValue={this.props.sampleMockValue}
           textLabel='Current Sample Value: '
         />
-        <EditorWrapper>
-          <ContractEditor />
-        </EditorWrapper>
+        <EditorComponent />
         <LibraryComponent
           templatesArray={this.props.templates}
           uploadCTA={this.state.upload}

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Tile } from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
+import styled from 'styled-components';
 
 import { getTemplates, addNewTemplateAction } from '../../actions/templatesActions';
 import { updateModelMockAction } from '../../actions/modelActions';
@@ -16,6 +17,12 @@ const mockUpload = () => { console.log('upload'); };
 const mockImport = () => { console.log('import'); };
 const mockAddTemp = () => { console.log('addTemp'); };
 const mockAddToCont = (input) => { console.log('addToCont: ', input); };
+
+const TileWrapper = styled.div`
+display: flex;
+width: 65vw;
+border: 2px solid #F9F9F9;
+`;
 
 export class App extends PureComponent {
   constructor(props) {
@@ -48,27 +55,29 @@ export class App extends PureComponent {
     return (
       <div>
         <Header />
-        <Tile
-          handleSubmit={this.props.updateModelMock}
-          header='Model'
-          label='Model Mock: '
-          textValue={this.props.modelMockValue}
-          textLabel='Current Model Value: '
-        />
-        <Tile
-          handleSubmit={this.props.updateLogicMock}
-          header='Logic'
-          label='Logic Mock: '
-          textValue={this.props.logicMockValue}
-          textLabel='Current Logic Value: '
-        />
-        <Tile
-          handleSubmit={this.props.updateSampleMock}
-          header='Sample'
-          label='Sample Mock: '
-          textValue={this.props.sampleMockValue}
-          textLabel='Current Sample Value: '
-        />
+        <TileWrapper>
+          <Tile
+            handleSubmit={this.props.updateModelMock}
+            header='Model'
+            label='Model Mock: '
+            textValue={this.props.modelMockValue}
+            textLabel='Current Model Value: '
+          />
+          <Tile
+            handleSubmit={this.props.updateLogicMock}
+            header='Logic'
+            label='Logic Mock: '
+            textValue={this.props.logicMockValue}
+            textLabel='Current Logic Value: '
+          />
+          <Tile
+            handleSubmit={this.props.updateSampleMock}
+            header='Sample'
+            label='Sample Mock: '
+            textValue={this.props.sampleMockValue}
+            textLabel='Current Sample Value: '
+          />
+        </TileWrapper>
         <EditorComponent />
         <LibraryComponent
           templatesArray={this.props.templates}

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
-import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { TemplateLibrary, Tile } from '@accordproject/cicero-ui';
+import { Tile } from '@accordproject/cicero-ui';
 import 'semantic-ui-css/semantic.min.css';
 import { connect } from 'react-redux';
 
@@ -10,25 +9,12 @@ import { updateModelMockAction } from '../../actions/modelActions';
 import { updateLogicMockAction } from '../../actions/logicActions';
 import { updateSampleMockAction } from '../../actions/sampleActions';
 import Header from '../Header';
+import LibraryComponent from '../TemplateLibrary';
 
 const mockUpload = () => { console.log('upload'); };
 const mockImport = () => { console.log('import'); };
 const mockAddTemp = () => { console.log('addTemp'); };
 const mockAddToCont = (input) => { console.log('addToCont: ', input); };
-
-const TLWrapper = styled.div`
-  height: 700px;
-  width: 485px;
-  position: fixed;
-  bottom: 0;
-  right: 0;
-  border: 2px solid #F9F9F9;
-  overflow-y: auto;
-  &::-webkit-scrollbar {
-    width: 4px;
-    background: transparent;
-  }
-`;
 
 export class App extends PureComponent {
   constructor(props) {
@@ -82,15 +68,13 @@ export class App extends PureComponent {
           textValue={this.props.sampleMockValue}
           textLabel='Current Sample Value: '
         />
-        <TLWrapper>
-          <TemplateLibrary
-            templates={this.props.templates}
-            upload={this.state.upload}
-            import={this.state.import}
-            addTemp={this.props.addNewTemplate}
-            addToCont={this.state.addToCont}
-          />
-        </TLWrapper>
+        <LibraryComponent
+          templatesArray={this.props.templates}
+          uploadCTA={this.state.upload}
+          importTemplate={this.state.import}
+          addNewTemplate={this.props.addNewTemplate}
+          addToContract={this.state.addToCont}
+        />
       </div>
     );
   }

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -7,11 +7,17 @@ import { App } from './index';
 const templates = [];
 const fetchAPTemplates = () => null;
 const addNewTemplate = () => null;
+const updateLogicMock = () => null;
+const updateModelMock = () => null;
+const updateSampleMock = () => null;
 
 const props = {
   templates,
   fetchAPTemplates,
   addNewTemplate,
+  updateLogicMock,
+  updateModelMock,
+  updateSampleMock,
 };
 
 describe('<App />', () => {

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ContractEditor } from '@accordproject/cicero-ui';
+
+const EditorWrapper = styled.div`
+height: 530px;
+width: calc(100vw - 485px);
+position: fixed;
+bottom: 0;
+left: 0;
+border: 2px solid #F9F9F9;
+overflow-y: auto;
+&::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+}
+`;
+
+const EditorComponent = () => (
+    <EditorWrapper>
+      <ContractEditor />
+    </EditorWrapper>
+);
+
+export default EditorComponent;

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ContractEditor } from '@accordproject/cicero-ui';
 
 const EditorWrapper = styled.div`
-height: 530px;
+height: 700px;
 width: calc(100vw - 485px);
 position: fixed;
 bottom: 0;

--- a/src/containers/TemplateLibrary/index.js
+++ b/src/containers/TemplateLibrary/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { TemplateLibrary } from '@accordproject/cicero-ui';
+
+const TLWrapper = styled.div`
+height: 700px;
+width: 485px;
+position: fixed;
+bottom: 0;
+right: 0;
+border: 2px solid #F9F9F9;
+overflow-y: auto;
+&::-webkit-scrollbar {
+  width: 4px;
+  background: transparent;
+}
+`;
+
+const LibraryComponent = props => (
+    <TLWrapper>
+        <TemplateLibrary
+        templates={props.templatesArray}
+        upload={props.uploadCTA}
+        import={props.importTemplate}
+        addTemp={props.addNewTemplate}
+        addToCont={props.addToContract}
+        />
+    </TLWrapper>
+);
+
+LibraryComponent.propTypes = {
+  templatesArray: PropTypes.array,
+  uploadCTA: PropTypes.func,
+  importTemplate: PropTypes.func,
+  addNewTemplate: PropTypes.func,
+  addToContract: PropTypes.func,
+};
+
+export default LibraryComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-import App from './containers/App';
+import MainApp from './containers/App';
 import store from './store';
 
 const wrapper = document.getElementById('root');
-wrapper ? ReactDOM.render(<Provider store={store}><App /></Provider>, wrapper) : false;
+wrapper ? ReactDOM.render(<Provider store={store}><MainApp /></Provider>, wrapper) : false;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 
 import MainApp from './containers/App';
 import store from './store';
 
-const wrapper = document.getElementById('root');
-wrapper ? ReactDOM.render(<Provider store={store}><MainApp /></Provider>, wrapper) : false;
+render(<Provider store={store}><MainApp /></Provider>, document.querySelector('#root'));


### PR DESCRIPTION
# Issue #4 
## Working from accordproject/cicero-ui/pull/29

### Changes:
- Modularize `TemplateLibrary` component
- Adjust import name in `src` for linting
- Render `ContractEditor`
- Refactor the `render` method for `react-dom`
- Update mock `props` for `PropTypes` in the test
- Abstract out and modularize `ContractEditor`

### **FLAGS**:
- ~~`ContractEditor` needs to be modularized, similar to `TemplateLibrary`~~
- [Cicero-UI](https://github.com/accordproject/cicero-ui/pull/29) needs to be transpiled and/or built prior to linking with `npm link`