### PR TITLE
feat(ContractEditor): add markdown to store and render from store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5499,7 +5499,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5517,11 +5518,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5534,15 +5537,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5645,7 +5651,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5655,6 +5662,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5667,17 +5675,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5694,6 +5705,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5766,7 +5778,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5776,6 +5789,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5851,7 +5865,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5881,6 +5896,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5898,6 +5914,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5936,11 +5953,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10266,16 +10285,16 @@
       }
     },
     "react-redux": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
-      "integrity": "sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.0.3.tgz",
+      "integrity": "sha512-vYZA7ftOYlDk3NetitsI7fLjryt/widNl1SLXYvFenIpm7vjb4ryK0EeFrgn62usg5fYkyIAWNUPKnwWPevKLg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.4.3",
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.2"
+        "react-is": "^16.8.6"
       }
     },
     "react-table": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-monaco-editor": "^0.25.1",
-    "react-redux": "^6.0.0",
+    "react-redux": "^7.0.1",
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.0.2",

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -1,7 +1,4 @@
-export const markdownChanged = (markdown) => {
-  console.log('type', typeof markdown);
-  return ({
-    type: 'MARKDOWN_CHANGED',
-    markdown,
-  });
-};
+export const markdownChanged = markdown => ({
+  type: 'MARKDOWN_CHANGED',
+  markdown,
+});

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -1,0 +1,7 @@
+export const markdownChanged = (markdown) => {
+  console.log('type', typeof markdown);
+  return ({
+    type: 'MARKDOWN_CHANGED',
+    markdown,
+  });
+};

--- a/src/containers/App/__snapshots__/index.test.js.snap
+++ b/src/containers/App/__snapshots__/index.test.js.snap
@@ -53,7 +53,7 @@ exports[`<App /> on initialization renders page correctly 1`] = `
       <Segment
         basic={true}
       >
-        <Connect(LibraryComponent) />
+        <ConnectFunction />
       </Segment>
     </Sidebar>
     <SidebarPusher>
@@ -77,6 +77,10 @@ exports[`<App /> on initialization renders page correctly 1`] = `
           panes={
             Array [
               Object {
+                "menuItem": "Text",
+                "render": [Function],
+              },
+              Object {
                 "menuItem": "Model",
                 "render": [Function],
               },
@@ -91,6 +95,6 @@ exports[`<App /> on initialization renders page correctly 1`] = `
       </Segment>
     </SidebarPusher>
   </SidebarPushable>
-  <Connect(ErrorContainer) />
+  <ConnectFunction />
 </div>
 `;

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { ContractEditor } from '@accordproject/cicero-ui';
 import { loadTemplateObjectAction } from '../../actions/templatesActions';
+import { markdownChanged } from '../../actions/contractActions';
 import parseClause from '../../utilities/parseClause';
 
 const EditorWrapper = styled.div`
@@ -22,6 +23,8 @@ const EditorContainer = props => (
     <ContractEditor
       loadTemplateObject={props.loadTemplateObject}
       parseClause={(uri, text, clauseId) => parseClause(props.templateObjs, uri, text, clauseId)}
+      onChange={props.onEditorChange}
+      markdown={props.markdown}
     />
   </EditorWrapper>
 );
@@ -29,14 +32,18 @@ const EditorContainer = props => (
 EditorContainer.propTypes = {
   loadTemplateObject: PropTypes.func.isRequired,
   templateObjs: PropTypes.object,
+  onEditorChange: PropTypes.func.isRequired,
+  markdown: PropTypes.string,
 };
 
 const mapStateToProps = state => ({
   templateObjs: state.templatesState.templateObjs,
+  markdown: state.contractState.markdown,
 });
 
 const mapDispatchToProps = dispatch => ({
   loadTemplateObject: value => dispatch(loadTemplateObjectAction(value)),
+  onEditorChange: (value, markdown) => dispatch(markdownChanged(markdown))
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditorContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(React.memo(EditorContainer));

--- a/src/reducers/contractReducer.js
+++ b/src/reducers/contractReducer.js
@@ -1,0 +1,17 @@
+const initialState = {
+  markdown: '',
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'MARKDOWN_CHANGED':
+      return {
+        ...state,
+        markdown: action.markdown,
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@ import modelReducer from './reducers/modelReducer';
 import logicReducer from './reducers/logicReducer';
 import sampleReducer from './reducers/sampleReducer';
 import clauseReducer from './reducers/clauseReducer';
+import contractReducer from './reducers/contractReducer';
 import rootSaga from './sagas/rootSaga';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   logicState: logicReducer,
   sampleState: sampleReducer,
   clauseState: clauseReducer,
+  contractState: contractReducer,
 });
 
 const store = createStore(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,6 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-
-// const CopyWebpackPlugin = require('copy-webpack-plugin');
-// const webpack = require('webpack');
 const path = require('path');
 
 module.exports = {
@@ -92,6 +89,7 @@ module.exports = {
   resolve: {
     alias: {
       'styled-components': path.resolve(__dirname, 'node_modules', 'styled-components'),
+      react: path.resolve('./node_modules/react')
     },
   },
 };


### PR DESCRIPTION
chore(webpack): add react alias to avoid hooks warning
feat(ContractEditor): add markdown to store and render from store
chore(react-redux): update react-redux to 7

**Note:**
wraps EditorContainer in `React.memo` to prevent re-renders if prop values haven't changed to avoid infinite loop

***FLAGS***
Currently, when the markdown gets rendered from the store, the markdown shows that the `clause` block starts on the same line as the header before it, so it gets rendered as a header instead of a clause block. This seems to be an issue with the `MarkdownEditor` component, so I'm looking into it separately from this PR.
**UPDATE**: fix for the above "flag" is here: https://github.com/accordproject/cicero-ui/pull/50