### PR TITLE
fix(sagas): correct clause spacing and parsing - NA

### DIFF
--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -55,6 +55,7 @@ export function* addToContract(action) {
   ${metadata.getSample()}
   \`\`\``;
 
+    // Create a new paragraph in markdown for spacing between clauses
     const paragraphSpaceMd = 'This is a new clause!';
     const spacerValue = fromMarkdown.convert(paragraphSpaceMd);
     const paragraphSpaceNode = spacerValue.toJSON().document.nodes[0];
@@ -67,6 +68,8 @@ export function* addToContract(action) {
     const { nodes } = newSlateValue.document;
 
     // add the clause node to the Slate dom at current position
+    // Temporary fix to separate clauses, adding the new paragraph at
+    // end of splice
     nodes.splice(currentPosition, 0, clauseNode, paragraphSpaceNode);
 
     // update contract on store with new slate and md values

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -54,6 +54,11 @@ export function* addToContract(action) {
     const clauseMd = `\`\`\` <clause src=${action.uri} clauseId=${clauseId}>
   ${metadata.getSample()}
   \`\`\``;
+
+    const paragraphSpaceMd = 'This is a new clause!';
+    const spacerValue = fromMarkdown.convert(paragraphSpaceMd);
+    const paragraphSpaceNode = spacerValue.toJSON().document.nodes[0];
+
     const value = fromMarkdown.convert(clauseMd);
     const clauseNode = value.toJSON().document.nodes[0];
 
@@ -62,7 +67,7 @@ export function* addToContract(action) {
     const { nodes } = newSlateValue.document;
 
     // add the clause node to the Slate dom at current position
-    nodes.splice(currentPosition, 0, clauseNode);
+    nodes.splice(currentPosition, 0, clauseNode, paragraphSpaceNode);
 
     // update contract on store with new slate and md values
     yield put(actions.documentEdited(Value.fromJSON(newSlateValue), newMd));


### PR DESCRIPTION
# Issue N/A
Implement temporary fix for both clauses having no spacing in between them and some clauses parsing incorrectly

### Changes
- Add a stock text line after each clause
- Implement a `roundTrip` + rebuild grammar functionality for parsing whitespace correctly

### Flags
- These are temporary fixes for development
  - `roundTrip` should be handled in `cicero-core`, but awaiting resolution to [this issue](https://github.com/commonmark/commonmark.js/issues/83#issuecomment-512108246)
  - `markdown-editor` may need tweaking for adding a space after a clause

### Related Issues
- Issue #61
- [Cicero-UI 43](https://github.com/accordproject/cicero-ui/issues/43) 