### PR TITLE
feat(src): contract navigation component import - I55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -171,12 +171,12 @@
       }
     },
     "@accordproject/cicero-ui": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.23.tgz",
-      "integrity": "sha512-nnhFxxRECMJAxvcIPwQ9tDK0IHiCLFlIfmnQBLkM8u5IkudE/Ly39o0Kv5NvJT+sa6fd6tw0C2JOzn6NIhbhzQ==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.24.tgz",
+      "integrity": "sha512-iqOY6QGSZGQn0GHh9InxX4IE5Ob8+gUuiSOBibfDTBmMFjcVxdlXHrQs6ianju+5RQWYBWtJOQsNeb50q52/2Q==",
       "requires": {
         "@accordproject/cicero-core": "^0.13.4",
-        "@accordproject/markdown-editor": "^0.5.10",
+        "@accordproject/markdown-editor": "^0.5.11",
         "acorn": "5.1.2",
         "doctrine": "3.0.0",
         "lodash": "^4.17.15",
@@ -192,6 +192,30 @@
         "styled-components": "^4.3.2"
       },
       "dependencies": {
+        "@accordproject/markdown-editor": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.11.tgz",
+          "integrity": "sha512-oOna8bPvuaVa/WKV8ew2IRnS6/820RIQvHpKuXi28lfniwJi4uRhCYemp1WYExLm8RlY4yhKBTnvt229vriMKg==",
+          "requires": {
+            "commonmark": "^0.29.0",
+            "css-loader": "^3.0.0",
+            "immutable": "^3.8.2",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.6",
+            "react-dom": "^16.8.6",
+            "react-flipcard": "^0.2.1",
+            "react-immutable-proptypes": "^2.1.0",
+            "react-textarea-autosize": "^7.1.0",
+            "semantic-ui-css": "^2.4.1",
+            "semantic-ui-react": "^0.87.2",
+            "slate": "^0.47.4",
+            "slate-html-serializer": "^0.8.6",
+            "slate-plain-serializer": "^0.7.6",
+            "slate-react": "^0.22.4",
+            "style-loader": "^0.23.1",
+            "styled-components": "^4.3.2"
+          }
+        },
         "doctrine": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4097,7 +4121,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.1.0.tgz",
       "integrity": "sha512-MuL8WsF/KSrHCBCYaozBKlx+r7vIfUaDTEreo7wR7Vv3J6N0z6fqWjRk3e/6wjneitXN1r/Y9FTK1psYNOBdJQ==",
-      "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "cssesc": "^3.0.0",
@@ -4117,7 +4140,6 @@
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
           "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -4128,26 +4150,22 @@
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "schema-utils": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
           "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
-          "dev": true,
           "requires": {
             "ajv": "^6.1.0",
             "ajv-keywords": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/cicero-ui": "0.0.23",
+    "@accordproject/cicero-ui": "0.0.24",
     "@accordproject/ergo-compiler": "^0.9.4",
     "@accordproject/markdown-editor": "^0.5.10",
     "@babel/runtime": "^7.5.5",

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -26,10 +26,11 @@ export const addToContractAction = uri => ({
   uri,
 });
 
-export const addToContractSuccess = (clauseId, clauseTemplateRef) => ({
+export const addToContractSuccess = (clauseId, clauseTemplateRef, uri) => ({
   type: ADD_TO_CONTRACT_SUCCESS,
   clauseId,
   clauseTemplateRef,
+  uri,
 });
 
 export const removeFromContractAction = props => ({

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -14,10 +14,11 @@ export const documentEdited = (value, markdown) => ({
   markdown,
 });
 
-export const documentEditedSuccess = (value, markdown) => ({
+export const documentEditedSuccess = (value, markdown, headers) => ({
   type: DOCUMENT_EDITED_SUCCESS,
   slateValue: value,
   markdown,
+  headers,
 });
 
 export const addToContractAction = uri => ({

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -26,11 +26,10 @@ export const addToContractAction = uri => ({
   uri,
 });
 
-export const addToContractSuccess = (clauseId, clauseTemplateRef, uri) => ({
+export const addToContractSuccess = (clauseId, clauseTemplateRef) => ({
   type: ADD_TO_CONTRACT_SUCCESS,
   clauseId,
   clauseTemplateRef,
-  uri,
 });
 
 export const removeFromContractAction = props => ({

--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -1,14 +1,18 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
 import { Navigation } from '@accordproject/cicero-ui';
 
+import { navigateToHeader } from '../../utilities/navigateClause';
+
 import TextButton from '../../components/TextButton';
+import ClauseNav from './ClauseNav';
+import SubHeading from './SubHeadingBtn';
 import { setCurrentEditorAction } from '../../actions/appActions';
 
-import { AP_THEME, FILE_BAR } from '../App/themeConstants';
+import { AP_THEME, FILE_BAR, LEFT_NAV } from '../App/themeConstants';
 
 const LeftSidebar = styled.div`
   background-color: ${AP_THEME.DARK_BLUE};
@@ -59,8 +63,20 @@ const NavWrapper = styled.div`
   // overflow-y: inherit;
 `;
 
+const Heading = styled.h2`
+  color: ${LEFT_NAV.HEADING};
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 14px;
+  text-decoration: none;
+  text-align: left;
+  margin: 10px;
+`;
+
 export const LeftNav = (props) => {
+  const { setCurrentEditor, slateValue, clauses } = props;
   const [navVisible, setNavVisible] = useState(true);
+  const [showExpandedClause, setShowExpandedClause] = useState({});
 
   const buttonRef = useRef(null);
 
@@ -71,10 +87,17 @@ export const LeftNav = (props) => {
 
   const navigationPropsInput = {
     headers: props.headers,
+    navigateHeader: navigateToHeader,
     navigationProps: {
       NAVIGATE_SWITCH_FILES_VISIBLE: false,
     }
   };
+
+  const onClauseClick = useCallback((id) => {
+    setShowExpandedClause({ ...showExpandedClause, [id]: !showExpandedClause[id] });
+  }, [showExpandedClause]);
+
+  const clauseNodes = slateValue.toJSON().document.nodes.filter(node => node.type === 'clause');
 
   return (
     <LeftSidebar>
@@ -88,11 +111,35 @@ export const LeftNav = (props) => {
       onClick={handleClick}
       display={'block'}
     >
-      { navVisible ? '< Hide Navigation' : 'Show Navigation >'}
+      { navVisible ? 'Clause Navigation' : 'Contract Navigation'}
     </TextButton>
     <NavWrapper>
 
     {navVisible && <Navigation {...navigationPropsInput} />}
+      { !navVisible && <React.Fragment>
+        <Heading>CONTRACT</Heading>
+        <SubHeading onClick={() => setCurrentEditor(null, 'contract')}>Contract</SubHeading>
+        <br />
+        <Heading>CLAUSES</Heading>
+        { Object.keys(clauses).length
+          ? clauseNodes.map((clauseNode) => {
+            // clauseid is the id of the clause instance
+            const { clauseid, src } = clauseNode.data.attributes;
+            if (!clauses[clauseid]) return null;
+            // clauseTemplateRef is the id of the clause template which the clause is an instance of
+            const { clauseTemplateRef } = clauses[clauseid];
+            return (
+              <ClauseNav
+                key={clauseid}
+                showExpandedClause={showExpandedClause}
+                onClauseClick={onClauseClick}
+                clauseTemplateId={clauseTemplateRef}
+                src={src}
+                setCurrentEditor={setCurrentEditor}
+              />);
+          }) : null
+        }
+      </React.Fragment> }
     </NavWrapper>
     </LeftNavWrapper>
   </LeftSidebar>

--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -1,14 +1,14 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 
+import { Navigation } from '@accordproject/cicero-ui';
+
 import TextButton from '../../components/TextButton';
-import ClauseNav from './ClauseNav';
-import SubHeading from './SubHeadingBtn';
 import { setCurrentEditorAction } from '../../actions/appActions';
 
-import { AP_THEME, FILE_BAR, LEFT_NAV } from '../App/themeConstants';
+import { AP_THEME, FILE_BAR } from '../App/themeConstants';
 
 const LeftSidebar = styled.div`
   background-color: ${AP_THEME.DARK_BLUE};
@@ -18,7 +18,9 @@ const LeftSidebar = styled.div`
 const LeftNavWrapper = styled.div`
   padding: 15px;
   overflow-x: hidden;
+  overflow-y: hidden;
   background-color: ${AP_THEME.DARK_BLUE};
+  height: 100%;
 `;
 
 const FileOptions = styled.div`
@@ -53,22 +55,11 @@ const FileOptionButtons = styled.button`
 
 const NavWrapper = styled.div`
   padding-top: 10px;
-`;
-
-const Heading = styled.h2`
-  color: ${LEFT_NAV.HEADING};
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 14px;
-  text-decoration: none;
-  text-align: left;
-  margin: 10px;
+  height: 100%;
 `;
 
 export const LeftNav = (props) => {
-  const { setCurrentEditor, slateValue, clauses } = props;
   const [navVisible, setNavVisible] = useState(true);
-  const [showExpandedClause, setShowExpandedClause] = useState({});
 
   const buttonRef = useRef(null);
 
@@ -77,11 +68,6 @@ export const LeftNav = (props) => {
     buttonRef.current.blur();
   };
 
-  const onClauseClick = useCallback((id) => {
-    setShowExpandedClause({ ...showExpandedClause, [id]: !showExpandedClause[id] });
-  }, [showExpandedClause]);
-
-  const clauseNodes = slateValue.toJSON().document.nodes.filter(node => node.type === 'clause');
   return (
     <LeftSidebar>
       <FileOptions>
@@ -97,30 +83,8 @@ export const LeftNav = (props) => {
       { navVisible ? '< Hide Navigation' : 'Show Navigation >'}
     </TextButton>
     <NavWrapper>
-      { navVisible && <React.Fragment>
-        <Heading>CONTRACT</Heading>
-        <SubHeading onClick={() => setCurrentEditor(null, 'contract')}>Contract</SubHeading>
-        <br />
-        <Heading>CLAUSES</Heading>
-        { Object.keys(clauses).length
-          ? clauseNodes.map((clauseNode) => {
-            // clauseid is the id of the clause instance
-            const { clauseid, src } = clauseNode.data.attributes;
-            if (!clauses[clauseid]) return null;
-            // clauseTemplateRef is the id of the clause template which the clause is an instance of
-            const { clauseTemplateRef } = clauses[clauseid];
-            return (
-              <ClauseNav
-                key={clauseid}
-                showExpandedClause={showExpandedClause}
-                onClauseClick={onClauseClick}
-                clauseTemplateId={clauseTemplateRef}
-                src={src}
-                setCurrentEditor={setCurrentEditor}
-              />);
-          }) : null
-        }
-      </React.Fragment> }
+
+    {navVisible && <Navigation headers={props.headers} />}
     </NavWrapper>
     </LeftNavWrapper>
   </LeftSidebar>
@@ -128,6 +92,7 @@ export const LeftNav = (props) => {
 };
 
 LeftNav.propTypes = {
+  headers: PropTypes.array,
   slateValue: PropTypes.object.isRequired,
   setCurrentEditor: PropTypes.func.isRequired,
   clauses: PropTypes.object,
@@ -136,6 +101,7 @@ LeftNav.propTypes = {
 const mapStateToProps = state => ({
   slateValue: state.contractState.slateValue,
   clauses: state.contractState.clauses,
+  headers: state.contractState.headers,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -56,6 +56,7 @@ const FileOptionButtons = styled.button`
 const NavWrapper = styled.div`
   padding-top: 10px;
   height: 100%;
+  // overflow-y: inherit;
 `;
 
 export const LeftNav = (props) => {
@@ -66,6 +67,13 @@ export const LeftNav = (props) => {
   const handleClick = () => {
     setNavVisible(!navVisible);
     buttonRef.current.blur();
+  };
+
+  const navigationPropsInput = {
+    headers: props.headers,
+    navigationProps: {
+      NAVIGATE_SWITCH_FILES_VISIBLE: false,
+    }
   };
 
   return (
@@ -84,7 +92,7 @@ export const LeftNav = (props) => {
     </TextButton>
     <NavWrapper>
 
-    {navVisible && <Navigation headers={props.headers} />}
+    {navVisible && <Navigation {...navigationPropsInput} />}
     </NavWrapper>
     </LeftNavWrapper>
   </LeftSidebar>

--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -60,7 +60,6 @@ const FileOptionButtons = styled.button`
 const NavWrapper = styled.div`
   padding-top: 10px;
   height: 100%;
-  // overflow-y: inherit;
 `;
 
 const Heading = styled.h2`

--- a/src/reducers/contractReducer.js
+++ b/src/reducers/contractReducer.js
@@ -25,10 +25,82 @@ const initialState = {
           text: 'Welcome to Template Studio! Edit this text to get started.',
           marks: []
         }],
-      }]
+      },
+      /* Below temporary */
+      {
+        object: 'block',
+        type: 'heading_one',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Gestalt Design Service Agreement',
+          marks: []
+        }],
+      },
+      {
+        object: 'block',
+        type: 'paragraph',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque shipper, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae deliverable vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui receiver voluptatem sequi nesciunt.',
+          marks: []
+        }],
+      },
+      {
+        object: 'block',
+        type: 'heading_three',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Lorem Ipsum',
+          marks: []
+        }],
+      },
+      {
+        object: 'block',
+        type: 'paragraph',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.',
+          marks: []
+        }],
+      },
+      {
+        object: 'block',
+        type: 'heading_two',
+        data: {},
+        nodes: [{
+          object: 'text',
+          text: 'Confirmation of Receipt',
+          marks: []
+        }],
+      }
+      /* Above temporary */
+      ],
     }
   }),
   clauses: {},
+  /* Below temporary */
+  headers: [
+    {
+      key: '3',
+      text: 'Gestalt Design Service Agreement',
+      type: 'heading_one'
+    },
+    {
+      key: '7',
+      text: 'Lorem Ipsum',
+      type: 'heading_three'
+    },
+    {
+      key: '11',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    }
+  ]
+  /* Above temporary */
 };
 
 const reducer = (state = initialState, action) => {
@@ -38,6 +110,7 @@ const reducer = (state = initialState, action) => {
         ...state,
         markdown: action.markdown,
         slateValue: action.slateValue,
+        headers: action.headers,
       };
     }
     case ADD_TO_CONTRACT_SUCCESS: {

--- a/src/reducers/contractReducer.js
+++ b/src/reducers/contractReducer.js
@@ -51,7 +51,6 @@ const reducer = (state = initialState, action) => {
             parseError: null,
             parseResult: null,
             clauseTemplateRef: action.clauseTemplateRef,
-            uri: action.uri,
           }
         }
       };

--- a/src/reducers/contractReducer.js
+++ b/src/reducers/contractReducer.js
@@ -25,147 +25,11 @@ const initialState = {
           text: 'Welcome to Template Studio! Edit this text to get started.',
           marks: []
         }],
-      },
-      /* Below temporary */
-      {
-        object: 'block',
-        type: 'heading_one',
-        data: {},
-        nodes: [{
-          object: 'text',
-          text: 'Gestalt Design Service Agreement',
-          marks: []
-        }],
-      },
-      {
-        object: 'block',
-        type: 'paragraph',
-        data: {},
-        nodes: [{
-          object: 'text',
-          text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque shipper, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae deliverable vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui receiver voluptatem sequi nesciunt.',
-          marks: []
-        }],
-      },
-      {
-        object: 'block',
-        type: 'heading_three',
-        data: {},
-        nodes: [{
-          object: 'text',
-          text: 'Lorem Ipsum',
-          marks: []
-        }],
-      },
-      {
-        object: 'block',
-        type: 'paragraph',
-        data: {},
-        nodes: [{
-          object: 'text',
-          text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.',
-          marks: []
-        }],
-      },
-      {
-        object: 'block',
-        type: 'heading_two',
-        data: {},
-        nodes: [{
-          object: 'text',
-          text: 'Confirmation of Receipt',
-          marks: []
-        }],
-      }
-      /* Above temporary */
-      ],
+      }],
     }
   }),
   clauses: {},
-  /* Below temporary */
-  headers: [
-    {
-      key: '3',
-      text: 'Gestalt Design Service Agreement',
-      type: 'heading_one'
-    },
-    {
-      key: '7',
-      text: 'Lorem Ipsum',
-      type: 'heading_three'
-    },
-    {
-      key: '11',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '12',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '13',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '14',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '15',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '16',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '17',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '21',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '22',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '23',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '24',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '25',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '26',
-      text: 'Confirmation of Receipt',
-      type: 'heading_two'
-    },
-    {
-      key: '27',
-      text: 'Bottom',
-      type: 'heading_two'
-    }
-  ]
-  /* Above temporary */
+  headers: [],
 };
 
 const reducer = (state = initialState, action) => {
@@ -175,7 +39,7 @@ const reducer = (state = initialState, action) => {
         ...state,
         markdown: action.markdown,
         slateValue: action.slateValue,
-        headers: action.headers,
+        headers: action.headers
       };
     }
     case ADD_TO_CONTRACT_SUCCESS: {

--- a/src/reducers/contractReducer.js
+++ b/src/reducers/contractReducer.js
@@ -98,6 +98,71 @@ const initialState = {
       key: '11',
       text: 'Confirmation of Receipt',
       type: 'heading_two'
+    },
+    {
+      key: '12',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '13',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '14',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '15',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '16',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '17',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '21',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '22',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '23',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '24',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '25',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '26',
+      text: 'Confirmation of Receipt',
+      type: 'heading_two'
+    },
+    {
+      key: '27',
+      text: 'Bottom',
+      type: 'heading_two'
     }
   ]
   /* Above temporary */
@@ -121,7 +186,8 @@ const reducer = (state = initialState, action) => {
           [action.clauseId]: {
             parseError: null,
             parseResult: null,
-            clauseTemplateRef: action.clauseTemplateRef
+            clauseTemplateRef: action.clauseTemplateRef,
+            uri: action.uri,
           }
         }
       };

--- a/src/sagas/actions.js
+++ b/src/sagas/actions.js
@@ -1,0 +1,14 @@
+import * as R from 'ramda';
+
+export const headingClause = node => node.type === 'clause';
+const headingOne = node => node.type === 'heading_one';
+const headingTwo = node => node.type === 'heading_two';
+const headingThree = node => node.type === 'heading_three';
+
+export const headingExists = R.anyPass([headingOne, headingTwo, headingThree]);
+
+export const clauseDisplayNameFinder = src => R
+  .path(['metadata', 'packageJson', 'displayName'], src);
+
+export const clauseNameFinder = src => R
+  .path(['metadata', 'packageJson', 'name'], src);

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -39,7 +39,9 @@ import {
 } from '../actions/constants';
 
 /**
- * saga to update the contract in the store if it has changed
+ * Saga to update the contract in the store if it has changed
+ * Determines if heading or clause nodes exist
+ * If so, populates an array to send to the store for navigation
  */
 export function* updateDocument(action) {
   const currentSlateValue = yield select(contractSelectors.slateValue);
@@ -59,14 +61,16 @@ export function* updateDocument(action) {
       headers.push(headerSlateObj);
     }
     if (ACT.headingClause(node)) {
+      const clauseId = node.data.get('attributes').clauseid;
       const clauseSrcUrl = node.data.get('attributes').src;
 
       const clauseDisplayName = ACT.clauseDisplayNameFinder(templates[clauseSrcUrl]);
       const clauseName = ACT.clauseNameFinder(templates[clauseSrcUrl]);
+
       const clauseNameText = clauseDisplayName || clauseName;
 
       const headerSlateObj = {
-        key: node.key,
+        key: clauseId,
         text: clauseNameText,
         type: node.type
       };

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -154,7 +154,7 @@ export function* addToContract(action) {
     }));
 
     // add instatiated clause to list of clauses in the contract state
-    yield put(actions.addToContractSuccess(clauseId, clauseTemplateId, action.uri));
+    yield put(actions.addToContractSuccess(clauseId, clauseTemplateId));
   } catch (err) {
     yield put(appActions.addAppError('Failed to add clause to contract', err));
   }

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -105,9 +105,7 @@ export function* addToContract(action) {
     const clauseNode = value.toJSON().document.nodes[0];
 
     const newSlateValue = JSON.parse(JSON.stringify(slateValue.toJSON()));
-    console.log('Fail before: ', newSlateValue);
     const newMd = toMarkdown.convert(newSlateValue);
-    console.log('Fail after');
     const { nodes } = newSlateValue.document;
 
     // add the clause node to the Slate dom at current position
@@ -134,7 +132,7 @@ export function* addToContract(action) {
     }));
 
     // add instatiated clause to list of clauses in the contract state
-    yield put(actions.addToContractSuccess(clauseId, clauseTemplateId));
+    yield put(actions.addToContractSuccess(clauseId, clauseTemplateId, action.uri));
   } catch (err) {
     yield put(appActions.addAppError('Failed to add clause to contract', err));
   }

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -112,7 +112,7 @@ export function* addToContract(action) {
     const metadata = templateObj.getMetadata();
 
     // get the user's current position in Slate dom to insert clause at
-    const currentPosition = slateValue.selection.anchor.path.get(0); // possibly here
+    const currentPosition = slateValue.selection.anchor.path.get(0);
     const clauseId = uuidv4(); // unique identifier for a clause instance
     const clauseMd = `\`\`\` <clause src=${action.uri} clauseId=${clauseId}>
   ${metadata.getSample()}

--- a/src/selectors/contractSelectors.js
+++ b/src/selectors/contractSelectors.js
@@ -1,3 +1,5 @@
 export const markdown = state => state.contractState.markdown;
 
 export const slateValue = state => state.contractState.slateValue;
+
+export const clauses = state => state.contractState.clauses;

--- a/src/utilities/navigateClause.js
+++ b/src/utilities/navigateClause.js
@@ -33,7 +33,7 @@ const findClauseNode = (clauseId) => {
   slateValue.document.nodes.forEach((node) => {
     if (node.type !== 'clause') return;
     if ((node.data.get('attributes').clauseid) === clauseId) {
-      clauseNode = node;
+      clauseNode = node.data.get('attributes').clauseid;
     }
   });
   return clauseNode;
@@ -44,9 +44,10 @@ const findClauseNode = (clauseId) => {
  * Decrements the key - possible bug within this process
  * Scrolls the document to the selected DOM element
  */
-const scrollToClause = (clauseNode) => {
-  const nodeKey = (clauseNode.key - 1).toString();
-  const selectedClauseNode = document.querySelector(`[data-key="${nodeKey}"]`);
+const scrollToClause = (clauseNodeId, type) => {
+  const selectedClauseNode = (type === 'clause')
+    ? document.getElementById(`${clauseNodeId}`)
+    : document.querySelector(`[data-key="${clauseNodeId}"]`);
   selectedClauseNode.scrollIntoView({ behavior: 'smooth' });
 };
 
@@ -62,7 +63,11 @@ const navigateToClauseError = (clause) => {
     noClauseError();
     return;
   }
-  scrollToClause(clauseNode);
+  scrollToClause(clauseNode, 'clause');
+};
+
+export const navigateToHeader = (clauseNode, type) => {
+  scrollToClause(clauseNode, type);
 };
 
 export default navigateToClauseError;

--- a/src/utilities/navigateClause.js
+++ b/src/utilities/navigateClause.js
@@ -40,8 +40,9 @@ const findClauseNode = (clauseId) => {
 };
 
 /**
- * Takes in a clause node to determine the Slate key
- * Decrements the key - possible bug within this process
+ * Takes in a clause node to determine a key
+ * Using the the Slate key for non clauses
+ * Using the clauseId for clauses
  * Scrolls the document to the selected DOM element
  */
 const scrollToClause = (clauseNodeId, type) => {


### PR DESCRIPTION
# Issue #55
Import `Navigation` component and handle navigation functionality and storing headers in store.

### Changes
- Construct headers object in saga when document is updated
  - Push to an array and place on store
  - Object holds `clauseid`, `displayName` or `name` text, and markdown `type`
- Adjust scroll to clause function to handle either `clauseid` or Slate `key`

### Flags
- Scrolling (using [`scrollIntoView`][scrollMDN]) currently bugs, showcased in [this Loom][loom].
- Placing `uri` in the store under the `clauses.clauseId` was reverted, this should not be an issue
  - I had begun by tracking the src before relying just on the `clauseId`

### Related Issues
- [Cicero UI Issue 91][cui]

[scrollMDN]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
[loom]: https://www.loom.com/share/aeee057f72664eefb2bef317afee79a3
[cui]: https://github.com/accordproject/cicero-ui/issues/91