### PR TITLE
fix(navigateClause): fix bug that caused page to move and toolbar to …

### DIFF
--- a/src/utilities/navigateClause.js
+++ b/src/utilities/navigateClause.js
@@ -49,7 +49,7 @@ const scrollToClause = (clauseNodeId, type) => {
   const selectedClauseNode = (type === 'clause')
     ? document.getElementById(`${clauseNodeId}`)
     : document.querySelector(`[data-key="${clauseNodeId}"]`);
-  selectedClauseNode.scrollIntoView({ behavior: 'smooth' });
+  selectedClauseNode.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
 };
 
 /**


### PR DESCRIPTION
This fixes the issue where the page scrolls and the toolbar disappears, but it seems like there is another issue where it scrolls to just below the element we are targeting. 