### PR TITLE
fix(sagas): adjust markdown to slate transitions - I81

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,10 +5335,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -121,23 +121,24 @@ export function* addToContract(action) {
     // Create a new paragraph in markdown for spacing between clauses
     const paragraphSpaceMd = 'This is a new clause!';
     const spacerValue = fromMarkdown.convert(paragraphSpaceMd);
-    const paragraphSpaceNode = spacerValue.toJSON().document.nodes[0];
+    const paragraphSpaceNodeJSON = spacerValue.toJSON().document.nodes[0];
 
-    const value = fromMarkdown.convert(clauseMd);
-    const clauseNode = value.toJSON().document.nodes[0];
+    const valueAsSlate = fromMarkdown.convert(clauseMd);
+    const clauseNodeJSON = valueAsSlate.toJSON().document.nodes[0];
+    const newSlateValueAsJSON = JSON.parse(JSON.stringify(slateValue.toJSON()));
 
-    const newSlateValue = JSON.parse(JSON.stringify(slateValue.toJSON()));
-    const newMd = toMarkdown.convert(newSlateValue);
-    const { nodes } = newSlateValue.document;
+    const { nodes } = newSlateValueAsJSON.document;
 
     // add the clause node to the Slate dom at current position
     // Temporary fix to separate clauses, adding the new paragraph at
-    // end of splice
-    nodes.splice(currentPosition, 0, clauseNode, paragraphSpaceNode);
+    // end of splice. Convert this all back to markdown
+    nodes.splice(currentPosition, 0, clauseNodeJSON, paragraphSpaceNodeJSON);
+    const realNewMd = toMarkdown.convert(Value.fromJSON(newSlateValueAsJSON));
 
     // update contract on store with new slate and md values
-    yield put(actions.documentEdited(Value.fromJSON(newSlateValue), newMd));
+    yield put(actions.documentEdited(Value.fromJSON(newSlateValueAsJSON), realNewMd));
     const grammar = templateObj.parserManager.getTemplatizedGrammar();
+
 
     // Temporary roundtrip and rebuild grammar
     const grammarRound = roundTrip(grammar);


### PR DESCRIPTION
# Issue #81
Correct issue for a clause to be added to a contract with existing headings without error

### Changes
- `npm audit fix` for a severe vulnerability in `eslint-utils`
- Fix the `markdown` <-> `slate` conversion
- Pass the *new* `markdown` to the redux store

### Flags
N/A

### Related Issues
N/A
