### PR TITLE
chore(package): increment versions for styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -171,12 +171,12 @@
       }
     },
     "@accordproject/cicero-ui": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.28.tgz",
-      "integrity": "sha512-iB8+GpOfqXpKN/lNI92yZw3/VV0n3wdOpmE+vkipGOg5m9QIoryjnCGsCA+vCbwXdI+i5dWNPHmTbs23cNLeRg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.0.30.tgz",
+      "integrity": "sha512-8RPhBE0JPfj9PsxnV6DLbJ/NjjPhxdyZfBMadEFoqFPrJ6+0Zcfm49SMYg2BEF6ScAFX+OolS5Vk4MmXkZlTwA==",
       "requires": {
         "@accordproject/cicero-core": "^0.13.4",
-        "@accordproject/markdown-editor": "^0.5.12",
+        "@accordproject/markdown-editor": "^0.5.14",
         "acorn": "5.1.2",
         "doctrine": "3.0.0",
         "lodash": "^4.17.15",
@@ -188,8 +188,7 @@
         "react-dom": "^16.8.6",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.87.2",
-        "slate": "^0.47.4",
-        "styled-components": "^4.3.2"
+        "slate": "^0.47.4"
       },
       "dependencies": {
         "doctrine": {
@@ -240,9 +239,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.12.tgz",
-      "integrity": "sha512-yLAJsbydLwpXudwvSflrTODKeBQnhtp0XuqpS7ztUiDIt0CTHRJgAGq63lHLsOxV3F3ZCnj+aq5kJXmV7IpvDg==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.5.14.tgz",
+      "integrity": "sha512-uQ0CAICqH5AEimzQOJcLNUcvevCEFux6OTQNlLOWGQU/X/iL3ObirRFWRcj49irdq03qlfZywBEK1nfwrn7B+g==",
       "requires": {
         "commonmark": "^0.29.0",
         "css-loader": "^3.0.0",
@@ -259,8 +258,7 @@
         "slate-html-serializer": "^0.8.6",
         "slate-plain-serializer": "^0.7.6",
         "slate-react": "^0.22.4",
-        "style-loader": "^0.23.1",
-        "styled-components": "^4.3.2"
+        "style-loader": "^0.23.1"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/cicero-ui": "0.0.28",
+    "@accordproject/cicero-ui": "0.0.30",
     "@accordproject/ergo-compiler": "^0.9.4",
-    "@accordproject/markdown-editor": "^0.5.12",
+    "@accordproject/markdown-editor": "^0.5.14",
     "@babel/runtime": "^7.5.5",
     "mixin-deep": "^2.0.1",
     "monaco-editor": "^0.15.1",

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -10,7 +10,7 @@ import { AP_THEME, CONTRACT_EDITOR } from '../App/themeConstants';
 
 const EditorWrapper = styled.div`
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   &::-webkit-scrollbar {
     width: 6px;
     background: transparent;


### PR DESCRIPTION
# No Issue
Increment versions and horizontal scroll when `TemplateLibrary` is covering the `ContractEditor`

### Changes
N/A

### Flags
- Further work will be needed to have `TemplateLibrary` and the right sidebar entirely remove when clicking to hide or the screen is below a certain width.

### Related Issues
N/A
