### PR TITLE
feat(Error): convert array of errors to object with indexed errors - I86

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.13.4",
-    "@accordproject/cicero-ui": "0.1.2",
+    "@accordproject/cicero-ui": "0.1.3",
     "@accordproject/ergo-compiler": "^0.9.4",
     "@accordproject/markdown-slate": "^0.4.8",
     "@babel/runtime": "^7.5.5",

--- a/src/containers/Error/errorReducer.js
+++ b/src/containers/Error/errorReducer.js
@@ -8,6 +8,6 @@ const parseErrorGather = state => R.toPairs(R.path(['contractState', 'clauses'],
   .map(([clauseId, clause]) => ({ clauseId, parseError: clause.parseError }))
   .filter(({ parseError }) => !R.isNil(parseError));
 
-const errorsGenerator = state => [...modelErrorGather(state), ...parseErrorGather(state)];
+const errorsGenerator = state => ({ ...R.indexBy(R.prop('clauseTemplateId'), modelErrorGather(state)), ...R.indexBy(R.prop('clauseId'), parseErrorGather(state))});
 
 export default errorsGenerator;


### PR DESCRIPTION
# Issue #86 
Right now, the errors get added to an array every time a clause is parsed. This means if multiple changes cause a clause to be parsed multiple times, the same error will be added to the array multiple times and we end up with multiple of the same error.

### Changes
- Convert array of errors to an object with indexed errors

### Flags
- Needs update in cicero-ui for errors management, see related issue

### Related Issues
- Issue #86 
- accordproject/cicero-ui#137
