### PR TITLE
Changes to FileOptionsButtons to look like buttons

### DIFF
--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -31,29 +31,41 @@ const FileOptions = styled.div`
   height: 36px;
   padding-left: 5px;
   background-color: ${FILE_BAR.BACKGROUND};
+  
 `;
 
 const FileOptionButtons = styled.button`
   margin: 8px;
-  border: 0;
+  border: 2px solid ${FILE_BAR.OPTION_BUTTONS};
+  border-radius: 5px;
   background: transparent;
+  padding: 10px 10px 10px 10px !important;
   font-size: inherit;
   color: ${FILE_BAR.OPTION_BUTTONS};
   display: inline-block;
   cursor: pointer;
-  text-decoration: underline;
+  text-decoration: none;
   &:hover {
     color: ${FILE_BAR.OPTION_BUTTONS_HOVER};
-    text-decoration: underline;
+    text-decoration: none;
+    padding: 10px 10px 10px 10px !important;
+    border: 2px solid ${FILE_BAR.OPTION_BUTTONS_HOVER};
+    border-radius: 5px;
   }
   &:focus {
     outline: none;
     color: ${FILE_BAR.OPTION_BUTTONS_HOVER};
-    text-decoration: underline;
+    text-decoration: none;
+    padding: 10px 10px 10px 10px !important;
+    border: 2px solid ${FILE_BAR.OPTION_BUTTONS_HOVER};
+    border-radius: 5px;
   }
   &:active {
     color: ${FILE_BAR.OPTION_BUTTONS_HOVER};
-    text-decoration: underline;
+    text-decoration: none;
+    padding: 10px 10px 10px 10px !important;
+    border: 2px solid ${FILE_BAR.OPTION_BUTTONS_HOVER};
+    border-radius: 5px;
   }
 `;
 


### PR DESCRIPTION
The previous look with the underline is changed to make the button like border appearance

# Issue #<NUMBER HERE>
<OVERALL SUMMARY OF PULL REQUEST>
The pull is an addition of a feature to make the File Options look like buttons
### Changes
- <INSERT DESCRIPTION OF CHANGES>
Each file option is given padding and border with radius to make it appear like a button
  - <SUB NOTES OF DESCRIPTIONS>
- <SUMMARIZE ALL COMMITS IN PULL REQUEST>

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

### Related Issues
- Issue #<NUMBER HERE>
- Pull Request #<NUMBER HERE>
110