### PR TITLE
fix(containers): add css related to FireFox scrollbar - I115

### DIFF
--- a/src/containers/ClauseTemplate/ClauseExampleTextEditor.js
+++ b/src/containers/ClauseTemplate/ClauseExampleTextEditor.js
@@ -8,6 +8,7 @@ import { editClauseSampleAction } from '../../actions/clauseTemplatesActions';
 const EditorWrapper = styled.div`
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-color: rgba(0,0,0,.25) rgba(0,0,0,.1);
   &::-webkit-scrollbar {
     width: 6px;
     background: transparent;

--- a/src/containers/ClauseTemplate/ClauseGrammarEditor.js
+++ b/src/containers/ClauseTemplate/ClauseGrammarEditor.js
@@ -8,6 +8,7 @@ import { editClauseGrammarAction } from '../../actions/clauseTemplatesActions';
 const EditorWrapper = styled.div`
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-color: rgba(0,0,0,.25) rgba(0,0,0,.1);
   &::-webkit-scrollbar {
     width: 6px;
     background: transparent;

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -15,6 +15,8 @@ import {
 const EditorWrapper = styled.div`
   overflow-y: auto;
   overflow-x: auto;
+  scrollbar-color: rgba(0,0,0,.25) rgba(0,0,0,.1);
+  scrollbar-width: thin;
   &::-webkit-scrollbar {
     width: 6px;
     background: transparent;

--- a/src/containers/LeftNav/index.js
+++ b/src/containers/LeftNav/index.js
@@ -23,6 +23,7 @@ const LeftNavWrapper = styled.div`
   padding: 15px;
   overflow-x: hidden;
   overflow-y: hidden;
+  scrollbar-color: transparent transparent;
   background-color: ${AP_THEME.DARK_BLUE};
   height: 100%;
 `;

--- a/src/containers/TemplateLibrary/index.js
+++ b/src/containers/TemplateLibrary/index.js
@@ -25,6 +25,7 @@ const TLWrapper = styled.div`
   position: relative;
   height: inherit;
   padding-right: 10px;
+  scrollbar-color: rgba(0,0,0,.25) rgba(0,0,0,.1);
 
   &::-webkit-scrollbar {
     width: 4px;


### PR DESCRIPTION
# Issue #115
PR adding some css to make scrollbar similar in Firefox bellow version 71.

### Changes
Just added colors and widths using `scrollbar-color` and `scrollbar-width`.
