### PR TITLE
fixed padding on the right sidebar

### DIFF
--- a/src/containers/TemplateLibrary/index.js
+++ b/src/containers/TemplateLibrary/index.js
@@ -24,7 +24,8 @@ const TLWrapper = styled.div`
   width: 355px;
   position: relative;
   height: inherit;
-  padding-right: 10px;
+  padding-left: 15px;
+  padding-right: 15px;
   scrollbar-color: rgba(0,0,0,.25) rgba(0,0,0,.1);
 
   &::-webkit-scrollbar {


### PR DESCRIPTION
# Issue #<NUMBER HERE>
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- Fixed padding of the template library sidebar

### Flags
- Currently the right sidebar pane did not have any padding or margin, which made it strictly squeeze with the scrollbar
ref #124 