### PR TITLE
feat(contractSaga): add empty paragraphs before/after - I145

### DIFF
--- a/src/sagas/contractSaga.js
+++ b/src/sagas/contractSaga.js
@@ -109,10 +109,20 @@ export function* addToContract(action) {
   ${metadata.getSample()}
   \`\`\``;
 
-    // Create a new paragraph in markdown for spacing between clauses
-    const paragraphSpaceMd = 'This is a new clause!';
-    const spacerValue = slateTransformer.fromMarkdown(paragraphSpaceMd);
-    const paragraphSpaceNodeJSON = spacerValue.toJSON().document.nodes[0];
+    // Create a new paragraph in JSON for spacing between clauses
+    const paragraphSpaceNodeJSON = {
+      object: 'block',
+      type: 'paragraph',
+      data: {
+      },
+      nodes: [
+        {
+          object: 'text',
+          text: '',
+          marks: []
+        }
+      ]
+    };
 
     const valueAsSlate = slateTransformer.fromMarkdown(clauseMd);
     const clauseNodeJSON = valueAsSlate.toJSON().document.nodes[0];
@@ -123,7 +133,7 @@ export function* addToContract(action) {
     // add the clause node to the Slate dom at current position
     // Temporary fix to separate clauses, adding the new paragraph at
     // end of splice. Convert this all back to markdown
-    nodes.splice(currentPosition, 0, clauseNodeJSON, paragraphSpaceNodeJSON);
+    nodes.splice((currentPosition + 1), 0, clauseNodeJSON, paragraphSpaceNodeJSON);
     const realNewMd = slateTransformer.toMarkdown(Value.fromJSON(newSlateValueAsJSON));
 
     // update contract on store with new slate and md values

--- a/src/sagas/templatesSaga.js
+++ b/src/sagas/templatesSaga.js
@@ -21,7 +21,7 @@ export function* pushTemplatesToStore() {
   try {
     const templateLibrary = new TemplateLibrary();
     const templateIndex = yield templateLibrary
-      .getTemplateIndex({ latestVersion: true, ciceroVersion });
+      .getTemplateIndex({ latestVersion: false, ciceroVersion });
     const templateIndexArray = Object.values(templateIndex);
     yield put(actions.getTemplatesSuccess(templateIndexArray));
   } catch (err) {


### PR DESCRIPTION
# Issue #145
Ensure a blank paragraph is before and after a clause

### Changes
- Remove filter of latest templates to remain in `v0.13`
- Ensure a blank paragraph is before and after a clause
  - Add blank paragraph node after any clause
  - Add a clause one node after current selection

### Flags
- Now two copies of templates are showing up in the library

### Related Issues
- [CTL Pull Request #301](https://github.com/accordproject/cicero-template-library/pull/301)
