### PR TITLE
feat(*): support copy paste and parse of clause - I85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,11 +243,11 @@
       }
     },
     "@accordproject/cicero-ui": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.3.0.tgz",
-      "integrity": "sha512-TaapDTqwh59+JOzvXDHqWMNE9XIrKsYItmaH1V1yieGBXsfWRo3SFSzQs/aj1Sm89frBAXCYrlZJ30zWPCApoA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-ui/-/cicero-ui-0.3.1.tgz",
+      "integrity": "sha512-XO9dVvsA/VTe1fe2Lm2/PbYooRNzgPusTwgY+rga4Okol9L2dLn2gpkAlZvTbWVQypGhRmU1S9Z3dkGsMO/eNA==",
       "requires": {
-        "@accordproject/markdown-editor": "^0.7.4",
+        "@accordproject/markdown-editor": "^0.7.5",
         "@accordproject/markdown-slate": "^0.8.2",
         "lodash": "^4.17.15",
         "mini-css-extract-plugin": "^0.7.0",
@@ -490,9 +490,9 @@
       }
     },
     "@accordproject/markdown-editor": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.7.4.tgz",
-      "integrity": "sha512-kt7YZwHxqUyWx7izxzuZazCzaNAvkQiThnZDfvCscGmRnhjb9gAJyYFfzTLgY7fDUNyR+3pfl54rogQmUh54og==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-editor/-/markdown-editor-0.7.5.tgz",
+      "integrity": "sha512-iaMYrH17XawNjBpvx6HwwgBJKCg4ppp4SecAlHU242P9p2R7qnNqW5cN4QrfA05NIFzOkx08ub3zg5ZormM3WA==",
       "requires": {
         "@accordproject/markdown-slate": "^0.8.2",
         "css-loader": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "^0.20.3",
-    "@accordproject/cicero-ui": "^0.3.0",
+    "@accordproject/cicero-ui": "^0.3.1",
     "@accordproject/ergo-compiler": "^0.20.1",
     "@accordproject/markdown-slate": "^0.8.2",
     "@babel/runtime": "^7.7.2",

--- a/src/actions/contractActions.js
+++ b/src/actions/contractActions.js
@@ -52,10 +52,11 @@ export const parseClauseError = (clauseId, error) => ({
   error,
 });
 
-export const pasteToContractAction = (clauseId, clauseTemplateRef) => ({
+export const pasteToContractAction = (clauseId, clauseTemplateRef, text) => ({
   type: PASTE_TO_CONTRACT,
   clauseId,
   clauseTemplateRef,
+  text
 });
 
 export const pasteToContractSuccess = (clauseId, clauseTemplateRef) => ({

--- a/src/containers/ContractEditor/index.js
+++ b/src/containers/ContractEditor/index.js
@@ -88,8 +88,8 @@ const mapDispatchToProps = dispatch => ({
   loadTemplateObject: value => dispatch(loadTemplateObjectAction(value)),
   onEditorChange: (value, markdown) => dispatch(documentEdited(value, markdown)),
   removeFromContract: value => dispatch(removeFromContractAction(value)),
-  pasteToContract: (clause, template, text) => dispatch(pasteToContractAction(
-    clause, template, text
+  pasteToContract: (clauseId, templateUri, text) => dispatch(pasteToContractAction(
+    clauseId, templateUri, text
   )),
 });
 

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,7 @@ body, html {
   overflow-x: auto;
 }
 
-h1, h2, h3, h4, h5, h6, p, a, button {
+h1, h2, h3, h4, h5, h6, p, a, ul, ol, li, button {
   font-family: 'Graphik', sans-serif !important;
 }
 

--- a/src/utilities/onClauseUpdated.js
+++ b/src/utilities/onClauseUpdated.js
@@ -1,9 +1,7 @@
-import { Clause, Template } from '@accordproject/cicero-core';
+import { Clause } from '@accordproject/cicero-core';
 import { SlateTransformer } from '@accordproject/markdown-slate';
 import store from '../store';
 import { parseClauseSuccess, parseClauseError } from '../actions/contractActions';
-
-const slateTransformer = new SlateTransformer();
 
 /**
  * Parses user inputted text for a template using Cicero


### PR DESCRIPTION
# Issue #85
Handle Copy + Paste of a clause from duplicate `clauseId` to parsing

### Changes
- Correct `pasteToContract` call
- Provide font support in lists
- Removed extra code
- Increment `cicero-ui`

### Flags
- N/A

### [Deployed Netlify](https://5dd45b199acd0800085b8e61--accordproject-studio.netlify.com/)
